### PR TITLE
Fix run server on run_tests script is kept waiting to exit

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,6 +2,6 @@
 
 echo "Running tests..."
 
-composer run dev --timeout=0
+composer run dev --timeout=0 &
 
 composer test


### PR DESCRIPTION
In our company we use Behat Imbo API extension.

In order to be able to update GuzzleHttp we need this change to be done in v2.x of the IMBO/Behat API extension library.

Thanks!